### PR TITLE
Fix styleUrls property in AppComponent

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,7 @@ import { RouterOutlet } from '@angular/router';
   selector: 'app-root',
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.css'
+  styleUrls: ['./app.component.css']
 })
 export class AppComponent {
   title = 'prueba-uno';


### PR DESCRIPTION
## Summary
- fix property name for component styles

## Testing
- `npx tsc -p tsconfig.spec.json --noEmit`
- `npm run test:headless` *(fails: Chrome missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_688029db27ac832eb4347271f3d8bc7c